### PR TITLE
add passed days classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ If you don't set an option, the default will be used. You can [look up the defau
     "selectedTime": "rd-time-selected",
     "time": "rd-time",
     "timeList": "rd-time-list",
-    "timeOption": "rd-time-option"
+    "timeOption": "rd-time-option",
+    "passedDay": "rd-day-passed"
   },
   "time": true,
   "timeFormat": "HH:mm",

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -508,16 +508,23 @@ function calendar (calendarOptions) {
 
     function part (data) {
       var i, day, node;
+      var today = momentum.moment()
       for (i = 0; i < data.length; i++) {
+        var passedDay = '';
         if (tr.children.length === weekdayCount) {
           tr = dom({ type: 'tr', className: o.styles.dayRow, parent: month.body });
         }
         day = data.base.clone().add(i, 'days');
+        if (day.month() == today.month() &&
+            day.month() == ref.month() &&
+            day.date() < today.date()) {
+          passedDay = ' ' + o.styles.passedDay;
+        }
         node = dom({
           type: 'td',
           parent: tr,
           text: day.format(o.dayFormat),
-          className: validationTest(day, data.cell.join(' ').split(' ')).join(' ')
+          className: validationTest(day, data.cell.join(' ').split(' ')).join(' ') + passedDay
         });
         if (data.selectable && day.date() === current) {
           selectDayElement(node);

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -101,6 +101,7 @@ function defaults (options, cal) {
   if (styl.time === no) { styl.time = 'rd-time'; }
   if (styl.timeList === no) { styl.timeList = 'rd-time-list'; }
   if (styl.timeOption === no) { styl.timeOption = 'rd-time-option'; }
+  if (styl.passedDay === no) { styl.passedDay = 'rd-day-passed'; }
 
   return o;
 }


### PR DESCRIPTION
Adds the 'rd-day-passed' class for days within the current (chronological) and within the current (displayed) month.

Needed to style these outlined days below for https://github.com/SpiderStrategies/Scoreboard/issues/24858

*Current date in the screenshot is Jan 14th*
![Screen Shot 2019-07-09 at 7 57 24 PM](https://user-images.githubusercontent.com/7981518/60930522-fc5ed680-a283-11e9-965c-43078f0d131d.png)

